### PR TITLE
Fixed a minor issue in the Calendar component

### DIFF
--- a/src/main/untangled/components/ui/component/calendar.cljs
+++ b/src/main/untangled/components/ui/component/calendar.cljs
@@ -211,8 +211,7 @@
                                                     (dom/th #js {:key label :className "o-day-name"} (tr-unsafe label)))))
                                (dom/tbody nil
                                           (for [week weeks]
-                                            (dom/tr #js {:key (str (.getDate (first week)) "-" (.getMonth (first week)))
-                                                         :className "week"}
+                                            (dom/tr #js {:key (.toUTCString (first week)) :className "week"}
                                                     (for [day week]
                                                       (dom/td #js {
                                                                    :key       (str "d" (.getMonth day) "-" (.getDate day))

--- a/src/main/untangled/components/ui/component/calendar.cljs
+++ b/src/main/untangled/components/ui/component/calendar.cljs
@@ -211,7 +211,8 @@
                                                     (dom/th #js {:key label :className "o-day-name"} (tr-unsafe label)))))
                                (dom/tbody nil
                                           (for [week weeks]
-                                            (dom/tr #js {:key (.getDate (first week)) :className "week"}
+                                            (dom/tr #js {:key (str (.getDate (first week)) "-" (.getMonth (first week)))
+                                                         :className "week"}
                                                     (for [day week]
                                                       (dom/td #js {
                                                                    :key       (str "d" (.getMonth day) "-" (.getDate day))


### PR DESCRIPTION
The key that was set on the 'week' part of the calendar did not create
keys that were unique enough, this can be seen when switching to March
2017, in which there are 2 occurences of weeks beginning on the 26th
(one in Feb, the other in Mar).
This included the month in the key as well to circumvent this.