### PR TITLE
Fix css-guide build error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
             [lein-cljsbuild "1.1.5"]
             [lein-doo "0.1.7"]]
 
-  :source-paths ["dev" "src/main" "src/guide" "src/visuals"]
+  :source-paths ["dev" "src/main" "src/guide" "src/visuals" "src/css-guide"]
   :test-paths ["src/test"]
   :jar-exclusions [#".DS_Store" #"public" #"cards" #"user.clj"]
 


### PR DESCRIPTION
Added the missing src-path to project.clj

Now you can run the css-guide as described with the following command.
`JVM_OPTS="-Dcss-guide" lein run -m clojure.main script/figwheel.clj`
and then navigate to http://localhost:8001/guide-css.html